### PR TITLE
Add Python requirement for package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ exclude = '''
 [tool.poetry.dependencies]
 # pydantic = {version = "2.0.2"}
 # compatible with Core ZenML
+python = ">=3.8,<3.12"
 pydantic = { version = "<1.11,>=1.9.0" }
 pyyaml = { version = "6.0" }
 click = { version = "8.1.3" }


### PR DESCRIPTION
The package currently advertises itself (on PyPi) as being compatible with Python <3. This fix corrects that so that only >=3 is possible.