### PR TITLE
Bump `pyyaml` for ZenML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ exclude = '''
 # compatible with Core ZenML
 python = ">=3.8,<3.12"
 pydantic = { version = "<1.11,>=1.9.0" }
-pyyaml = { version = "6.0" }
+pyyaml = { version = ">=6.0.1" }
 click = { version = "8.1.3" }
 python-terraform = { version = "^0.10.1" }
 rich = { version = "^13.5.2" }


### PR DESCRIPTION
ZenML and mlstacks were incompatible on account of this PyYaml dependency. I've amended `mlstacks` to allow both to be installed at the same time / in the same environment.