### PR TITLE
Bump incompatible packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,25 +72,25 @@ exclude = '''
 python = ">=3.8,<3.12"
 pydantic = { version = "<1.11,>=1.9.0" }
 pyyaml = { version = ">=6.0.1" }
-click = { version = "8.1.3" }
+click = { version = "^8.0.1,<8.1.4" }
 python-terraform = { version = "^0.10.1" }
-rich = { version = "^13.5.2" }
+rich = { version = "^12.0.0" }
 analytics-python = { version = "^1.4.0" }
 
 # dev dependencies
 black = { version = "^23.3.0", optional = true }
-ruff = { version = "^0.0.275", optional = true }
-pytest = { version = "^7.3.2", optional = true }
-mypy = { version = "^1.4.0", optional = true }
+ruff = { version = "^0.0.282", optional = true }
+pytest = { version = "^7.4.0", optional = true }
+mypy = { version = "^1.3.0", optional = true }
 darglint = { version = "^1.8.1", optional = true }
-hypothesis = { version = "^6.82.3", optional = true }
+hypothesis = { version = "^6.43.1", optional = true }
 types-PyYAML = { version = "^6.0.0", optional = true }
 pytest-clarity = { version = "^1.0.1", optional = true }
 pytest-randomly = { version = "^3.10.1", optional = true }
 pytest-cov = { version = "^4.1.0", optional = true }
 
 # mypy dependencies
-types-setuptools = { version = "^68.0", optional = true }
+types-setuptools = { version = "^57.4.2", optional = true }
 
 [tool.poetry.extras]
 dev = [


### PR DESCRIPTION
ZenML still not working with `mlstacks`... This PR fixes it.