### PR TITLE
Add missing `aws` flavor

### DIFF
--- a/src/mlstacks/enums.py
+++ b/src/mlstacks/enums.py
@@ -48,6 +48,7 @@ class ComponentFlavorEnum(str, Enum):
     TEKTON = "tekton"
     MINIO = "minio"
     GCP = "gcp"
+    AWS = "aws"
 
 
 class DeploymentMethodEnum(str, Enum):


### PR DESCRIPTION
Used primarily for container registries.