### PR TITLE
Add `zenml` <-> `mlstacks` compatibility check to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,29 @@ jobs:
       python-version: "3.8"
     secrets: inherit
 
-  publish-python-package:
+  # checks zenml and mlstacks can be installed together in same environment
+  compatibility-check:
     needs: lint-unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install current package as editable
+        run: pip install -e .
+
+      - name: Install zenml package
+        run: pip install zenml
+
+      - name: Check for broken dependencies
+        run: pip check
+
+  publish-python-package:
+    needs: [lint-unit-test, compatibility-check]
     uses: ./.github/workflows/publish-pypi-package.yml
     secrets: inherit


### PR DESCRIPTION
This adds a step to the release workflow to ensure that releases don't happen if both `zenml` (current / latest version) and `mlstacks` (editable install of the release branch) are unable to be installed in the same environment.