### PR TITLE
Fix reference to empty eks resource when creating S3

### DIFF
--- a/aws-modular/eks.tf
+++ b/aws-modular/eks.tf
@@ -85,7 +85,7 @@ resource "aws_eks_node_group" "nodegroup" {
 }
 
 resource "aws_iam_role" "ng" {
-  count = local.enable_eks || var.enable_artifact_store ? 1 : 0
+  count = local.enable_eks ? 1 : 0
 
   name_prefix = "${local.prefix}-${local.eks.cluster_name}-ng"
   assume_role_policy = jsonencode({

--- a/aws-modular/s3.tf
+++ b/aws-modular/s3.tf
@@ -24,13 +24,13 @@ resource "aws_s3_bucket_public_access_block" "example" {
 }
 
 resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
-  count  = var.enable_artifact_store ? 1 : 0
+  count  = local.enable_eks ? 1 : 0
   bucket = aws_s3_bucket.zenml-artifact-store[0].id
   policy = data.aws_iam_policy_document.allow_access_from_another_account[0].json
 }
 
 data "aws_iam_policy_document" "allow_access_from_another_account" {
-  count = var.enable_artifact_store ? 1 : 0
+  count = local.enable_eks ? 1 : 0
   statement {
     principals {
       type        = "AWS"


### PR DESCRIPTION
The following error pops up if you create only an S3 bucket.

> │ Error: Invalid index
│ 
│   on eks.tf line 103, in resource "aws_iam_role" "ng":
│  103:           Federated = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${aws_eks_cluster.cluster[0].identity[0].oidc[0].issuer}"
│     ├────────────────
│     │ aws_eks_cluster.cluster is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no
│ elements.

This PR fixes this.