### PR TITLE
Fix "Permission Denied" error while executing dig script

### DIFF
--- a/modules/nginx-ingress-module/output.tf
+++ b/modules/nginx-ingress-module/output.tf
@@ -12,7 +12,7 @@ output "ingress-ip-address" {
 }
 
 data "external" "getIP" {
-  program = ["sh", "${path.module}/dig.sh"]
+  program = ["${path.module}/dig.sh"]
 
   query = {
     hostname = data.kubernetes_service.nginx-ingress-controller.status.0.load_balancer.0.ingress.0.hostname

--- a/modules/nginx-ingress-module/output.tf
+++ b/modules/nginx-ingress-module/output.tf
@@ -12,7 +12,7 @@ output "ingress-ip-address" {
 }
 
 data "external" "getIP" {
-  program = ["${path.module}/dig.sh"]
+  program = ["sh", "${path.module}/dig.sh"]
 
   query = {
     hostname = data.kubernetes_service.nginx-ingress-controller.status.0.load_balancer.0.ingress.0.hostname

--- a/src/mlstacks/terraform/modules/nginx-ingress-module/output.tf
+++ b/src/mlstacks/terraform/modules/nginx-ingress-module/output.tf
@@ -12,7 +12,7 @@ output "ingress-ip-address" {
 }
 
 data "external" "getIP" {
-  program = ["${path.module}/dig.sh"]
+  program = ["sh", "${path.module}/dig.sh"]
 
   query = {
     hostname = data.kubernetes_service.nginx-ingress-controller.status.0.load_balancer.0.ingress.0.hostname


### PR DESCRIPTION
While creating the eks module, the following error might pop up if the dig script inside the nginx module is not executable.

> Error: External Program Lookup Failed
> ...

This PR removes the need for the script to be executable.