### PR TITLE
Stop CI from running on push to `develop` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,11 @@ on:
   workflow_call:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    # paths-ignore: ["**.md", "!pyproject.toml"]
+    paths-ignore: ["**.md", "!pyproject.toml"]
   push:
     branches:
       - main
-      - develop
-    # paths-ignore: ["**.md", "!pyproject.toml"]
+    paths-ignore: ["**.md", "!pyproject.toml"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
As with https://github.com/zenml-io/zenml/pull/1788, this PR stops the CI from running on push to `develop`.