### PR TITLE
Update outputs.tf to make `project_id` match GCP usage

### DIFF
--- a/src/mlstacks/terraform/gcp-modular/outputs.tf
+++ b/src/mlstacks/terraform/gcp-modular/outputs.tf
@@ -142,7 +142,7 @@ output "model_deployer_configuration" {
 }
 
 # project id
-output "project-id" {
+output "project_id" {
   value = var.project_id
 }
 


### PR DESCRIPTION
Tiny fix to make the outputs for `project_id` match the value / usage in GCP.

@wjayesh is there any reason I should NOT make this change? Also potentially a breaking change if someone's depending on the outputs to be fixed?