### PR TITLE
Close quotes on `kubernetes_context` values in `gcp-modular`

### DIFF
--- a/src/mlstacks/terraform/gcp-modular/output_file.tf
+++ b/src/mlstacks/terraform/gcp-modular/output_file.tf
@@ -33,19 +33,19 @@ resource "local_file" "stack_file" {
         id: ${uuid()}
         flavor: kubeflow
         name: gke_kubeflow_orchestrator
-        configuration: {"kubernetes_context": "gke_${local.prefix}-${local.gke.cluster_name}, "synchronous": True}
+        configuration: {"kubernetes_context": "gke_${local.prefix}-${local.gke.cluster_name}", "synchronous": True}
 %{else}
 %{if var.enable_orchestrator_tekton}
         id: ${uuid()}
         flavor: tekton
         name: gke_tekton_orchestrator
-        configuration: {"kubernetes_context": "gke_${local.prefix}-${local.gke.cluster_name}}
+        configuration: {"kubernetes_context": "gke_${local.prefix}-${local.gke.cluster_name}"}
 %{else}
 %{if var.enable_orchestrator_kubernetes}
         id: ${uuid()}
         flavor: kubernetes
         name: gke_kubernetes_orchestrator
-        configuration: {"kubernetes_context": "gke_${local.prefix}-${local.gke.cluster_name}, "synchronous": True}
+        configuration: {"kubernetes_context": "gke_${local.prefix}-${local.gke.cluster_name}", "synchronous": True}
 %{else}
 %{if var.enable_orchestrator_skypilot}
         id: ${uuid()}
@@ -99,7 +99,7 @@ resource "local_file" "stack_file" {
         id: ${uuid()}
         flavor: kserve
         name: gke_kserve
-        configuration: {"kubernetes_context": "gke_${local.prefix}-${local.gke.cluster_name}, "kubernetes_namespace": "${local.kserve.workloads_namespace}", "base_url": "${var.enable_model_deployer_kserve ? module.kserve[0].kserve-base-URL : ""}", "secret": "gcp_kserve_secret"}
+        configuration: {"kubernetes_context": "gke_${local.prefix}-${local.gke.cluster_name}", "kubernetes_namespace": "${local.kserve.workloads_namespace}", "base_url": "${var.enable_model_deployer_kserve ? module.kserve[0].kserve-base-URL : ""}", "secret": "gcp_kserve_secret"}
 %{else}
 %{if var.enable_model_deployer_seldon}
       model_deployer:


### PR DESCRIPTION
Failure to close quotations in the `stack_file` `kubernetes_context` values leads to errors like

```sh
Importing stack 'mlops' into ZenML...
...
ParserError: while parsing a flow mapping
  in "<unicode string>", line 27, column 24:
            configuration: {"kubernetes_context": "gke_zenm ... 
                           ^
expected ',' or '}', but got '<scalar>'
  in "<unicode string>", line 27, column 75:
     ... t": "gke_zenml-cluster-6i6x, "synchronous": True}
                                         ^
```

when running commands such as

```sh
mlstacks deploy -f stack.yaml -d
zenml stack deploy -p gcp -n mlops -r us-east4 -f stack.yaml -d
```

in zenml `v0.44.2` and mlstacks `v0.7.5`.