### PR TITLE
Use remote stack Terraform Registry modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,9 +162,9 @@ jobs:
         run: |
           for dir in $(ls -d src/mlstacks/terraform/* | grep -Fv -e "modules" -e ".github" | grep "gcp*"); do
               (cd $dir && terraform init -backend-config="path=$dir")
-              (cd $dir && terraform fmt -check -var="project_id=something" -var="bucket_name=something")
-              (cd $dir && terraform validate -var="project_id=something" -var="bucket_name=something")
-              (cd $dir && terraform plan -input=false -var="project_id=something" -var="bucket_name=something")
+              (cd $dir && terraform fmt -check -var='project_id=something' -var='bucket_name=something')
+              (cd $dir && terraform validate -var='project_id=something' -var='bucket_name=something')
+              (cd $dir && terraform plan -input=false -var='project_id=something' -var='bucket_name=something')
           done
 
   azure_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           for dir in $(ls -d src/mlstacks/terraform/* | grep -Fv -e "modules" -e ".github" | grep "gcp*"); do
               (cd $dir && terraform init -backend-config="path=$dir")
-              (cd $dir && terraform fmt -check -var='project_id=something' -var='bucket_name=something')
+              (cd $dir && terraform fmt -check)
               (cd $dir && terraform validate -var='project_id=something' -var='bucket_name=something')
               (cd $dir && terraform plan -input=false -var='project_id=something' -var='bucket_name=something')
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           for dir in $(ls -d src/mlstacks/terraform/* | grep -Fv -e "modules" -e ".github" | grep "gcp*"); do
               (cd $dir && terraform init -backend-config="path=$dir")
               (cd $dir && terraform fmt -check)
-              (cd $dir && terraform validate -var='project_id=something' -var='bucket_name=something')
+              (cd $dir && terraform validate)
               (cd $dir && terraform plan -input=false -var='project_id=something' -var='bucket_name=something')
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,9 +162,9 @@ jobs:
         run: |
           for dir in $(ls -d src/mlstacks/terraform/* | grep -Fv -e "modules" -e ".github" | grep "gcp*"); do
               (cd $dir && terraform init -backend-config="path=$dir")
-              (cd $dir && terraform fmt -check)
-              (cd $dir && terraform validate)
-              (cd $dir && terraform plan -input=false)
+              (cd $dir && terraform fmt -check -var="project_id=something" -var="bucket_name=something")
+              (cd $dir && terraform validate -var="project_id=something" -var="bucket_name=something")
+              (cd $dir && terraform plan -input=false -var="project_id=something" -var="bucket_name=something")
           done
 
   azure_test:

--- a/.gitignore
+++ b/.gitignore
@@ -151,4 +151,4 @@ terraform.tfstate
 terraform.tfstate.backup
 
 # used for testing
-src/mlstacks/terraform/aws-remote-state/values.tfvars.json
+testing.tfvars.json

--- a/src/mlstacks/cli/cli.py
+++ b/src/mlstacks/cli/cli.py
@@ -166,9 +166,17 @@ def destroy(file: str, debug: bool = False, yes: bool = False) -> None:
         yaml_dict = load_yaml_as_dict(file)
         stack_name: str = str(yaml_dict.get("name"))
         provider: str = str(yaml_dict.get("provider"))
+        try:
+            remote_state_bucket = get_remote_state_bucket(stack_path=file)
+        except FileNotFoundError:
+            remote_state_bucket = None
         declare(f"Destroying stack '{stack_name}' from '{file}'...")
         try:
-            destroy_stack(stack_path=file, debug_mode=debug)
+            destroy_stack(
+                stack_path=file,
+                debug_mode=debug,
+                remote_state_bucket=remote_state_bucket,
+            )
         except ValueError:
             error("Couldn't find stack files to destroy.")
 

--- a/src/mlstacks/terraform/aws-remote-state/main.tf
+++ b/src/mlstacks/terraform/aws-remote-state/main.tf
@@ -2,64 +2,12 @@ provider "aws" {
   region = var.region
 }
 
-resource "aws_s3_bucket" "terraform_state" {
-  bucket = var.bucket_name
+module "aws-remote-state" {
+  source  = "zenml-io/terraform-aws-remote-state"
+  version = ">=0.1.3"
 
-  # Prevent accidental deletion of this S3 bucket
-  lifecycle {
-    prevent_destroy = true
-  }
-
-  # set to true when you want to delete the bucket
-  # force_destroy = true
-}
-
-resource "aws_s3_bucket_ownership_controls" "tf_state_ownership" {
-  bucket = aws_s3_bucket.terraform_state.id
-
-  rule {
-    object_ownership = "BucketOwnerPreferred"
-  }
-}
-
-resource "aws_s3_bucket_request_payment_configuration" "tf_state_payment" {
-  bucket = aws_s3_bucket.terraform_state.id
-  payer  = "Requester"
-}
-
-resource "aws_s3_bucket_versioning" "enabled" {
-  bucket = aws_s3_bucket.terraform_state.id
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-# enable server-side encryption by default
-resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
-  bucket = aws_s3_bucket.terraform_state.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "public_access" {
-  bucket                  = aws_s3_bucket.terraform_state.id
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_dynamodb_table" "terraform_locks" {
-  name         = "terraform-up-and-running-locks"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "LockID"
-
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
+  region        = var.region
+  bucket_name   = var.bucket_name
+  force_destroy = var.force_destroy
+  tags          = var.tags
 }

--- a/src/mlstacks/terraform/aws-remote-state/main.tf
+++ b/src/mlstacks/terraform/aws-remote-state/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "aws-remote-state" {
-  source  = "zenml-io/terraform-aws-remote-state"
+  source  = "zenml-io/remote-state/aws"
   version = ">=0.1.3"
 
   region        = var.region

--- a/src/mlstacks/terraform/aws-remote-state/outputs.tf
+++ b/src/mlstacks/terraform/aws-remote-state/outputs.tf
@@ -1,3 +1,3 @@
-output "bucket_url" {
-  value = "s3://${aws_s3_bucket.terraform_state.bucket}"
+output "remote_state_bucket_url" {
+  value = module.aws-remote-state.bucket_url
 }

--- a/src/mlstacks/terraform/aws-remote-state/variables.tf
+++ b/src/mlstacks/terraform/aws-remote-state/variables.tf
@@ -7,3 +7,15 @@ variable "bucket_name" {
   description = "The name of the S3 bucket to deploy"
   default     = ""
 }
+
+variable "force_destroy" {
+  description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error"
+  default     = false
+  type        = bool
+}
+
+variable "tags" {
+  description = "A map of tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}

--- a/src/mlstacks/terraform/gcp-remote-state/main.tf
+++ b/src/mlstacks/terraform/gcp-remote-state/main.tf
@@ -3,17 +3,16 @@ provider "google" {
   region  = var.region
 }
 
-resource "google_storage_bucket" "terraform_state" {
-  name     = var.bucket_name
-  location = var.region
+module "gcp-remote-state" {
+  source  = "zenml-io/remote-state/gcp"
+  version = ">=0.1.3"
 
-  versioning {
-    enabled = true
-  }
+  region      = var.region
+  bucket_name = var.bucket_name
 
-  # set to true when you want to delete the bucket
-  # force_destroy = true
-
-  # Ensure no public access
-  uniform_bucket_level_access = true
+  force_destroy       = var.force_destroy
+  enable_versioning   = var.enable_versioning
+  block_public_access = var.block_public_access
+  labels              = var.labels
 }
+

--- a/src/mlstacks/terraform/gcp-remote-state/main.tf
+++ b/src/mlstacks/terraform/gcp-remote-state/main.tf
@@ -15,4 +15,3 @@ module "gcp-remote-state" {
   block_public_access = var.block_public_access
   labels              = var.labels
 }
-

--- a/src/mlstacks/terraform/gcp-remote-state/outputs.tf
+++ b/src/mlstacks/terraform/gcp-remote-state/outputs.tf
@@ -1,3 +1,3 @@
-output "bucket_url" {
-  value = "gs://${google_storage_bucket.terraform_state.name}"
+output "remote_state_bucket_url" {
+  value = module.gcp-remote-state.bucket_url
 }

--- a/src/mlstacks/terraform/gcp-remote-state/values.tfvars.json
+++ b/src/mlstacks/terraform/gcp-remote-state/values.tfvars.json
@@ -1,5 +1,0 @@
-{
-  "region": "europe-north1",
-  "project_id": "zenml-core",
-  "bucket_name": "mlstacks-gcp-state-easy-delete"
-}

--- a/src/mlstacks/terraform/gcp-remote-state/variables.tf
+++ b/src/mlstacks/terraform/gcp-remote-state/variables.tf
@@ -1,14 +1,39 @@
 variable "region" {
   description = "The region to deploy resources to"
-  default     = "eu-north-1"
+  default     = "europe-north1"
+  type        = string
 }
 
 variable "project_id" {
   description = "The project ID to deploy resources to"
-  default     = ""
+  type        = string
 }
 
 variable "bucket_name" {
   description = "The name of the GCS bucket to deploy"
-  default     = ""
+  type        = string
+}
+
+variable "force_destroy" {
+  description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error"
+  default     = false
+  type        = bool
+}
+
+variable "enable_versioning" {
+  description = "A boolean that indicates all objects should be versioned"
+  default     = true
+  type        = bool
+}
+
+variable "block_public_access" {
+  description = "A boolean that indicates to block public access to the bucket"
+  default     = true
+  type        = bool
+}
+
+variable "labels" {
+  description = "A map of bucket labels to add to all resources"
+  type        = map(string)
+  default     = {}
 }

--- a/src/mlstacks/utils/terraform_utils.py
+++ b/src/mlstacks/utils/terraform_utils.py
@@ -581,7 +581,7 @@ def _tf_client_output(
     state_path: str,
     output_key: Optional[str] = None,
 ) -> Dict[str, str]:
-    """Destroy Terraform changes.
+    """Get Terraform outputs.
 
     Args:
         runner: The Terraform runner.


### PR DESCRIPTION
- [x] Uses our Terraform registry modules instead of custom code inside the repository
- [x] (Updated for AWS and GCP, our two modular repositories)
- [x] Update Python code where needed in the `mlstacks` CLI deployment workflow
- [ ] Update docs telling people how it works + how to use the raw terraform vs the `mlstacks` way

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [ n] If my change requires a change to docs, I have updated the documentation
      accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting
      `develop`. If your branch wasn't based on develop read
      [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/mlstacks/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [ ] Other (add details above)
