### PR TITLE
Allow for custom DynamoDB table names for AWS remote state

### DIFF
--- a/src/mlstacks/terraform/aws-remote-state/main.tf
+++ b/src/mlstacks/terraform/aws-remote-state/main.tf
@@ -4,10 +4,11 @@ provider "aws" {
 
 module "aws-remote-state" {
   source  = "zenml-io/remote-state/aws"
-  version = ">=0.1.3"
+  version = ">=0.1.4"
 
-  region        = var.region
-  bucket_name   = var.bucket_name
-  force_destroy = var.force_destroy
-  tags          = var.tags
+  region              = var.region
+  bucket_name         = var.bucket_name
+  dynamodb_table_name = var.dynamo_table_name
+  force_destroy       = var.force_destroy
+  tags                = var.tags
 }

--- a/src/mlstacks/terraform/aws-remote-state/variables.tf
+++ b/src/mlstacks/terraform/aws-remote-state/variables.tf
@@ -1,11 +1,19 @@
 variable "region" {
   description = "The region to deploy resources to"
   default     = "eu-north-1"
+  type        = string
 }
 
 variable "bucket_name" {
   description = "The name of the S3 bucket to deploy"
   default     = ""
+  type        = string
+}
+
+variable "dynamo_table_name" {
+  description = "The name of the DynamoDB table to deploy"
+  default     = "terraform-remote-state-locks"
+  type        = string
 }
 
 variable "force_destroy" {


### PR DESCRIPTION
I updated [the base AWS remote state module](https://registry.terraform.io/modules/zenml-io/remote-state/aws/latest) to allow users to specify the dynamodb table name (esp in the case where they already have a table with a particular name and they want to avoid the conflict).

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation
      accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting
      `develop`. If your branch wasn't based on develop read
      [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/mlstacks/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [ ] Other (add details above)
