### PR TITLE
Fix exported yaml output for stack creation on `k3d`

### DIFF
--- a/src/mlstacks/terraform/k3d-modular/output_stack.tf
+++ b/src/mlstacks/terraform/k3d-modular/output_stack.tf
@@ -23,14 +23,14 @@ resource "local_file" "stack_file" {
         name: default
         configuration: {}
 %{endif}
-      container_registry:
 %{if var.enable_container_registry || var.enable_orchestrator_kubeflow || var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes}
+      container_registry:
         id: ${uuid()}
         flavor: default
         name: k3d-${local.k3d_registry.name}-${random_string.cluster_id.result}
         configuration:
           uri: "k3d-${local.k3d_registry.name}-${random_string.cluster_id.result}.localhost:${local.k3d_registry.port}"
-%{endif}          
+%{endif}
       orchestrator:
 %{if var.enable_orchestrator_kubeflow}
         id: ${uuid()}
@@ -63,7 +63,7 @@ resource "local_file" "stack_file" {
         id: ${uuid()}
         flavor: local
         name: default
-        configuration: {}        
+        configuration: {}
 %{endif}
 %{endif}
 %{endif}


### PR DESCRIPTION
Our `k3d` recipe mistakenly included container registries as exported for all components when this didn't apply when we were only including a minio artifact store e.g.

This PR fixes that.

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation
      accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting
      `develop`. If your branch wasn't based on develop read
      [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/mlstacks/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [ ] Other (add details above)
