### PR TITLE
Remove secrets manager

### DIFF
--- a/src/mlstacks/enums.py
+++ b/src/mlstacks/enums.py
@@ -22,7 +22,6 @@ class ComponentTypeEnum(str, Enum):
     ARTIFACT_STORE = "artifact_store"
     ORCHESTRATOR = "orchestrator"
     CONTAINER_REGISTRY = "container_registry"
-    SECRETS_MANAGER = "secrets_manager"
     DATA_VALIDATOR = "data_validator"
     EXPERIMENT_TRACKER = "experiment_tracker"
     MODEL_REGISTRY = "model_registry"

--- a/src/mlstacks/terraform/aws-modular/output_file.tf
+++ b/src/mlstacks/terraform/aws-modular/output_file.tf
@@ -62,14 +62,6 @@ resource "local_file" "stack_file" {
 %{endif}
 %{endif}
 
-%{if var.enable_secrets_manager}
-      secrets_manager:
-        id: ${uuid()}
-        flavor: aws
-        name: aws_secrets_manager
-        configuration: {"region_name": "${var.region}"}
-%{endif}
-
 %{if var.enable_experiment_tracker_mlflow}
       experiment_tracker:
         id: ${uuid()}

--- a/src/mlstacks/terraform/aws-modular/outputs.tf
+++ b/src/mlstacks/terraform/aws-modular/outputs.tf
@@ -84,24 +84,6 @@ output "experiment_tracker_configuration" {
   }) : ""
 }
 
-
-# if secrets manager is enabled, set the secrets manager outputs to the secrets manager values
-# otherwise, set the secrets manager outputs to empty strings
-output "secrets_manager_id" {
-  value = var.enable_secrets_manager ? uuid() : ""
-}
-output "secrets_manager_flavor" {
-  value = var.enable_secrets_manager ? "aws" : ""
-}
-output "secrets_manager_name" {
-  value = var.enable_secrets_manager ? "aws_secrets_manager_${random_string.unique.result}" : ""
-}
-output "secrets_manager_configuration" {
-  value = var.enable_secrets_manager ? jsonencode({
-    region_name = var.region
-  }) : ""
-}
-
 # if kserve is enabled, set the model deployer outputs to the kserve values
 # if seldon is enabled, set the model deployer outputs to the seldon values
 # otherwise, set the model deployer outputs to empty strings

--- a/src/mlstacks/terraform/aws-modular/variables.tf
+++ b/src/mlstacks/terraform/aws-modular/variables.tf
@@ -7,10 +7,6 @@ variable "enable_container_registry" {
   description = "Enable ECR deployment"
   default     = false
 }
-variable "enable_secrets_manager" {
-  description = "Enable Secret Manager deployment"
-  default     = false
-}
 variable "enable_orchestrator_kubeflow" {
   description = "Enable Kubeflow deployment"
   default     = false

--- a/src/mlstacks/terraform/aws-modular/variables.tf
+++ b/src/mlstacks/terraform/aws-modular/variables.tf
@@ -90,7 +90,7 @@ variable "mlflow_bucket" {
 # variables for creating a ZenML stack configuration file
 variable "zenml-version" {
   description = "The version of ZenML being used"
-  default     = "0.53.0"
+  default     = "0.53.1"
   type        = string
 }
 

--- a/src/mlstacks/terraform/aws-modular/variables.tf
+++ b/src/mlstacks/terraform/aws-modular/variables.tf
@@ -90,7 +90,7 @@ variable "mlflow_bucket" {
 # variables for creating a ZenML stack configuration file
 variable "zenml-version" {
   description = "The version of ZenML being used"
-  default     = "0.50.0"
+  default     = "0.53.0"
   type        = string
 }
 

--- a/src/mlstacks/terraform/gcp-modular/enable_services.tf
+++ b/src/mlstacks/terraform/gcp-modular/enable_services.tf
@@ -3,17 +3,8 @@ data "google_project" "project" {
   project_id = var.project_id
 }
 
-# You must have owner, editor, or service config editor roles 
+# You must have owner, editor, or service config editor roles
 # to be able to enable services.
-
-# enable secret manager
-resource "google_project_service" "secret_manager" {
-  count   = var.enable_secrets_manager ? 1 : 0
-  project = var.project_id
-  service = "secretmanager.googleapis.com"
-
-  disable_on_destroy = false
-}
 
 # enable container registry
 resource "google_project_service" "container_registry" {

--- a/src/mlstacks/terraform/gcp-modular/output_file.tf
+++ b/src/mlstacks/terraform/gcp-modular/output_file.tf
@@ -77,15 +77,6 @@ resource "local_file" "stack_file" {
         configuration: {"project": "${var.project_id}", "region": "${var.region}", "service_account_path": "${local_file.sa_key_file[0].filename}"}
 %{endif}
 
-
-%{if var.enable_secrets_manager}
-      secrets_manager:
-        id: ${uuid()}
-        flavor: gcp
-        name: gcp_secrets_manager
-        configuration: {"project_id": "${var.project_id}"}
-%{endif}
-
 %{if var.enable_experiment_tracker_mlflow}
       experiment_tracker:
         id: ${uuid()}

--- a/src/mlstacks/terraform/gcp-modular/outputs.tf
+++ b/src/mlstacks/terraform/gcp-modular/outputs.tf
@@ -100,23 +100,6 @@ output "experiment_tracker_configuration" {
   }) : ""
 }
 
-# if secrets manager is enabled, set the secrets manager outputs to the secrets manager values
-# otherwise, set the secrets manager outputs to empty strings
-output "secrets_manager_id" {
-  value = var.enable_secrets_manager ? uuid() : ""
-}
-output "secrets_manager_flavor" {
-  value = var.enable_secrets_manager ? "gcp" : ""
-}
-output "secrets_manager_name" {
-  value = var.enable_secrets_manager ? "gcp_secrets_manager_${random_string.unique.result}" : ""
-}
-output "secrets_manager_configuration" {
-  value = var.enable_secrets_manager ? jsonencode({
-    project_id = var.project_id
-  }) : ""
-}
-
 # if kserve is enabled, set the model deployer outputs to the kserve values
 # if seldon is enabled, set the model deployer outputs to the seldon values
 # otherwise, set the model deployer outputs to empty strings

--- a/src/mlstacks/terraform/gcp-modular/variables.tf
+++ b/src/mlstacks/terraform/gcp-modular/variables.tf
@@ -82,7 +82,7 @@ variable "mlflow-password" {
 # variables for creating a ZenML stack configuration file
 variable "zenml-version" {
   description = "The version of ZenML being used"
-  default     = "0.53.0"
+  default     = "0.53.1"
   type        = string
 }
 

--- a/src/mlstacks/terraform/gcp-modular/variables.tf
+++ b/src/mlstacks/terraform/gcp-modular/variables.tf
@@ -82,7 +82,7 @@ variable "mlflow-password" {
 # variables for creating a ZenML stack configuration file
 variable "zenml-version" {
   description = "The version of ZenML being used"
-  default     = "0.50.0"
+  default     = "0.53.0"
   type        = string
 }
 

--- a/src/mlstacks/terraform/gcp-modular/variables.tf
+++ b/src/mlstacks/terraform/gcp-modular/variables.tf
@@ -7,10 +7,6 @@ variable "enable_container_registry" {
   description = "Enable GCR deployment"
   default     = false
 }
-variable "enable_secrets_manager" {
-  description = "Enable Secret Manager deployment"
-  default     = false
-}
 variable "enable_orchestrator_kubeflow" {
   description = "Enable Kubeflow deployment"
   default     = false

--- a/src/mlstacks/terraform/k3d-modular/output_stack.tf
+++ b/src/mlstacks/terraform/k3d-modular/output_stack.tf
@@ -87,11 +87,6 @@ resource "local_file" "stack_file" {
           kubernetes_namespace: "${local.seldon.workloads_namespace}"
           base_url:  "http://${var.enable_model_deployer_seldon ? module.istio[0].ingress-ip-address : ""}"
           kubernetes_secret_name: "${var.seldon-secret-name}"
-      secrets_manager:
-        id: ${uuid()}
-        flavor: local
-        name: k3d-secrets-manager-${random_string.cluster_id.result}
-        configuration: {}
 %{endif}
     ADD
   filename = "./k3d_stack_${replace(substr(timestamp(), 0, 16), ":", "_")}.yaml"

--- a/src/mlstacks/terraform/k3d-modular/output_test_harness_cfg.tf
+++ b/src/mlstacks/terraform/k3d-modular/output_test_harness_cfg.tf
@@ -159,7 +159,6 @@ environments:
       - mlflow-local-tracker
       - mlflow-local-deployer
 %{endif}
-      - local-secrets-manager
 %{if var.enable_model_deployer_seldon}
       - k3d-seldon-${random_string.cluster_id.result}
 %{endif}
@@ -193,7 +192,6 @@ environments:
 %{if var.enable_model_deployer_kserve}
       - k3d-kserve-${random_string.cluster_id.result}
 %{endif}
-      - local-secrets-manager
     mandatory_requirements:
       - k3d-kubernetes-${random_string.cluster_id.result}
       - k3d-container-registry-${random_string.cluster_id.result}
@@ -222,7 +220,6 @@ environments:
 %{if var.enable_model_deployer_kserve}
       - k3d-kserve-${random_string.cluster_id.result}
 %{endif}
-      - local-secrets-manager
     mandatory_requirements:
       - k3d-kubeflow-${random_string.cluster_id.result}
       - k3d-container-registry-${random_string.cluster_id.result}
@@ -252,7 +249,6 @@ environments:
 %{if var.enable_model_deployer_kserve}
       - k3d-kserve-${random_string.cluster_id.result}
 %{endif}
-      - local-secrets-manager
     mandatory_requirements:
       - k3d-tekton-${random_string.cluster_id.result}
       - k3d-container-registry-${random_string.cluster_id.result}
@@ -278,7 +274,6 @@ environments:
       - mlflow-local-tracker
       - mlflow-local-deployer
 %{endif}
-      - local-secrets-manager
 %{if var.enable_model_deployer_seldon}
       - k3d-seldon-${random_string.cluster_id.result}
 %{endif}
@@ -317,7 +312,6 @@ environments:
 %{if var.enable_model_deployer_kserve}
       - k3d-kserve-${random_string.cluster_id.result}
 %{endif}
-      - local-secrets-manager
     mandatory_requirements:
       - k3d-kubernetes-${random_string.cluster_id.result}
       - k3d-container-registry-${random_string.cluster_id.result}
@@ -350,7 +344,6 @@ environments:
 %{if var.enable_model_deployer_kserve}
       - k3d-kserve-${random_string.cluster_id.result}
 %{endif}
-      - local-secrets-manager
     mandatory_requirements:
       - k3d-kubeflow-${random_string.cluster_id.result}
       - k3d-container-registry-${random_string.cluster_id.result}
@@ -383,7 +376,6 @@ environments:
 %{if var.enable_model_deployer_kserve}
       - k3d-kserve-${random_string.cluster_id.result}
 %{endif}
-      - local-secrets-manager
     mandatory_requirements:
       - k3d-tekton-${random_string.cluster_id.result}
       - k3d-container-registry-${random_string.cluster_id.result}

--- a/src/mlstacks/terraform/k3d-modular/variables.tf
+++ b/src/mlstacks/terraform/k3d-modular/variables.tf
@@ -77,7 +77,7 @@ variable "kserve-secret-name" {
 # variables for creating a ZenML stack configuration file
 variable "zenml-version" {
   description = "The version of ZenML being used"
-  default     = "0.50.0"
+  default     = "0.53.0"
   type        = string
 }
 

--- a/src/mlstacks/terraform/k3d-modular/variables.tf
+++ b/src/mlstacks/terraform/k3d-modular/variables.tf
@@ -77,7 +77,7 @@ variable "kserve-secret-name" {
 # variables for creating a ZenML stack configuration file
 variable "zenml-version" {
   description = "The version of ZenML being used"
-  default     = "0.53.0"
+  default     = "0.53.1"
   type        = string
 }
 


### PR DESCRIPTION
This pull request removes the secrets_manager enum and related code from the project. This change is necessary because the secrets_manager functionality is no longer needed and removing it will simplify the codebase.

Secrets manager is removed from the Terraform scripts as well as the stack output files. (Also removed from the enum of valid component types).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the Secrets Manager feature across various cloud service modules.

- **Documentation**
  - Updated comments to reflect changes in the required roles and outputs for enabled services.

- **Chores**
  - Cleaned up unused variables and output declarations related to the Secrets Manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->