### PR TITLE
Convert underscores to hyphens in AWS Quickstart docs

### DIFF
--- a/docs/book/getting-started/aws.md
+++ b/docs/book/getting-started/aws.md
@@ -50,7 +50,7 @@ name: "quickstart_s3_bucket"
 provider: aws
 metadata:
   config:
-    bucket_name: "quickstart_s3_bucket"
+    bucket_name: "quickstart-s3-bucket"
   tags:
     deployed-by: "mlstacks"
   region: "eu-north-1"


### PR DESCRIPTION
## Describe changes
Convert underscores in AWS Quickstart guide to hyphens to make it compatible with AWS resource naming requirements which do not allow underscores.

Tested on macOS 14.1.2 with AWS. 

Closes https://github.com/zenml-io/mlstacks/issues/127

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation
      accordingly.
- [ ] ~~I have added tests to cover my changes.~~
- [x] I have based my new branch on `develop` and the open PR is targeting
      `develop`. If your branch wasn't based on develop read
      [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/mlstacks/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Documentation changes.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [x] Other (add details above)
