### PR TITLE
Fix/analytics connection hang

### DIFF
--- a/src/mlstacks/analytics/client.py
+++ b/src/mlstacks/analytics/client.py
@@ -34,6 +34,7 @@ from mlstacks.utils.yaml_utils import load_yaml_as_dict
 logger = getLogger(__name__)
 
 analytics.write_key = "tU9BJvF05TgC29xgiXuKF7CuYP0zhgnx"
+analytics.max_retries = 0
 
 CONFIG_FILENAME = "config.yaml"
 

--- a/src/mlstacks/analytics/client.py
+++ b/src/mlstacks/analytics/client.py
@@ -161,7 +161,7 @@ def track_event(
         metadata: Dict of metadata to track.
 
     Returns:
-        True if event is sent successfully, False is not.
+        True if event is sent successfully, False otherwise.
     """
     if metadata is None:
         metadata = {}
@@ -169,8 +169,13 @@ def track_event(
     metadata.setdefault("event_success", True)
 
     with MLStacksAnalyticsContext() as analytics_context:
-        return bool(analytics_context.track(event=event, properties=metadata))
-    return False
+        try:
+            return bool(
+                analytics_context.track(event=event, properties=metadata)
+            )
+        except Exception:
+            logger.exception("Error occurred during analytics tracking")
+            return False
 
 
 class EventHandler:

--- a/src/mlstacks/analytics/client.py
+++ b/src/mlstacks/analytics/client.py
@@ -182,8 +182,6 @@ def track_event(
 
     metadata.setdefault("event_success", True)
 
-    analytics.write_key = "invalid_write_key_for_testing"
-
     with MLStacksAnalyticsContext() as analytics_context:
         return bool(analytics_context.track(event=event, properties=metadata))
     return False

--- a/src/mlstacks/analytics/client.py
+++ b/src/mlstacks/analytics/client.py
@@ -34,7 +34,7 @@ from mlstacks.utils.yaml_utils import load_yaml_as_dict
 logger = getLogger(__name__)
 
 analytics.write_key = "tU9BJvF05TgC29xgiXuKF7CuYP0zhgnx"
-analytics.max_retries = 0
+analytics.max_retries = 5
 
 CONFIG_FILENAME = "config.yaml"
 

--- a/src/mlstacks/analytics/client.py
+++ b/src/mlstacks/analytics/client.py
@@ -175,7 +175,7 @@ def track_event(
                 analytics_context.track(event=event, properties=metadata)
             )
         except Exception:
-            logger.exception("Error occurred during analytics tracking")
+            logger.debug("Unable to log analytics event. Please check network settings.")
 
     return False
 

--- a/src/mlstacks/analytics/client.py
+++ b/src/mlstacks/analytics/client.py
@@ -175,7 +175,9 @@ def track_event(
                 analytics_context.track(event=event, properties=metadata)
             )
         except Exception:
-            logger.debug("Unable to log analytics event. Please check network settings.")
+            logger.debug(
+                "Unable to log analytics event. Please check network settings."
+            )
 
     return False
 

--- a/src/mlstacks/analytics/client.py
+++ b/src/mlstacks/analytics/client.py
@@ -13,8 +13,8 @@
 """Analytics module for MLStacks."""
 
 import datetime
+import logging
 import os
-from logging import getLogger
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Type, cast
 from uuid import uuid4
@@ -31,7 +31,9 @@ from mlstacks.utils.analytics_utils import operating_system, python_version
 from mlstacks.utils.environment_utils import handle_bool_env_var
 from mlstacks.utils.yaml_utils import load_yaml_as_dict
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
+logging.getLogger("segment").disabled = True
+
 
 analytics.write_key = "tU9BJvF05TgC29xgiXuKF7CuYP0zhgnx"
 analytics.max_retries = 1

--- a/src/mlstacks/analytics/client.py
+++ b/src/mlstacks/analytics/client.py
@@ -176,7 +176,8 @@ def track_event(
             )
         except Exception:
             logger.exception("Error occurred during analytics tracking")
-            return False
+
+    return False
 
 
 class EventHandler:

--- a/tests/unit/analytics/__init__.py
+++ b/tests/unit/analytics/__init__.py
@@ -1,0 +1,12 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/unit/analytics/test_custom_on_error.py
+++ b/tests/unit/analytics/test_custom_on_error.py
@@ -1,3 +1,15 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
 import logging
 from typing import Any, Dict, List
 from unittest.mock import patch

--- a/tests/unit/analytics/test_custom_on_error.py
+++ b/tests/unit/analytics/test_custom_on_error.py
@@ -1,10 +1,10 @@
-import pytest
-from segment import analytics
 import logging
-from unittest.mock import patch, Mock
-import requests
 import uuid
+from unittest.mock import Mock, patch
 
+import pytest
+import requests
+from segment import analytics
 
 logger = logging.getLogger(__name__)
 analytics.max_retries = 0
@@ -13,8 +13,10 @@ analytics.max_retries = 0
 def mock_post_failure(*args, **kwargs):
     response = requests.Response()
     response.status_code = 500
-    response._content = b'{"error": "Simulated failure", "code": "internal_error"}'
-    response.headers['Content-Type'] = 'application/json'
+    response._content = (
+        b'{"error": "Simulated failure", "code": "internal_error"}'
+    )
+    response.headers["Content-Type"] = "application/json"
     return response
 
 
@@ -38,10 +40,11 @@ def reset_analytics_client():
 
 @pytest.mark.usefixtures("reset_analytics_client")
 def test_segment_custom_on_error_handler_invocation(caplog):
-    with caplog.at_level(logging.CRITICAL), \
-            patch('segment.analytics.request._session.post', side_effect=mock_post_failure), \
-            patch('segment.analytics.on_error', Mock()) as mock_on_error:
-        analytics.track('test_user_id', 'Test Event', {'property': 'value'})
+    with caplog.at_level(logging.CRITICAL), patch(
+        "segment.analytics.request._session.post",
+        side_effect=mock_post_failure,
+    ), patch("segment.analytics.on_error", Mock()) as mock_on_error:
+        analytics.track("test_user_id", "Test Event", {"property": "value"})
         analytics.flush()
 
     mock_on_error.assert_called()

--- a/tests/unit/analytics/test_custom_on_error.py
+++ b/tests/unit/analytics/test_custom_on_error.py
@@ -1,5 +1,6 @@
 import logging
-from unittest.mock import Mock, patch
+from typing import Any, Dict, List
+from unittest.mock import patch
 
 import requests
 from segment import analytics
@@ -10,10 +11,9 @@ logger = logging.getLogger(__name__)
 analytics.write_key = "tU9BJvF05TgC29xgiXuKF7CuYP0zhgnx"
 analytics.max_retries = 1
 
-analytics.on_error = Mock()
-
 
 def mock_post_failure(*args, **kwargs):
+    """Simulates a request failure."""
     response = requests.Response()
     response.status_code = 500
     response._content = (
@@ -23,7 +23,20 @@ def mock_post_failure(*args, **kwargs):
     return response
 
 
-def test_segment_custom_on_error_handler_invocation():
+def test_with_custom_on_error_handler():
+    """Tests that the custom on_error handler is called on error."""
+    handler_call_info = {"called": False}
+
+    def custom_on_error_handler(error: Exception, batch: List[Dict[str, Any]]):
+        handler_call_info["called"] = True
+        logger.debug(
+            "Custom on_error handler invoked:\nError: %s;\nBatch: %s",
+            error,
+            batch,
+        )
+
+    analytics.on_error = custom_on_error_handler
+
     with patch(
         "segment.analytics.request._session.post",
         side_effect=mock_post_failure,
@@ -31,4 +44,6 @@ def test_segment_custom_on_error_handler_invocation():
         analytics.track("test_user_id", "Test Event", {"property": "value"})
         analytics.flush()
 
-    analytics.on_error.assert_called()
+    assert handler_call_info[
+        "called"
+    ], "Custom on_error handler was not invoked"

--- a/tests/unit/analytics/test_custom_on_error.py
+++ b/tests/unit/analytics/test_custom_on_error.py
@@ -1,0 +1,34 @@
+import logging
+from unittest.mock import Mock, patch
+
+import requests
+from segment import analytics
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+analytics.write_key = "tU9BJvF05TgC29xgiXuKF7CuYP0zhgnx"
+analytics.max_retries = 1
+
+analytics.on_error = Mock()
+
+
+def mock_post_failure(*args, **kwargs):
+    response = requests.Response()
+    response.status_code = 500
+    response._content = (
+        b'{"error": "Simulated failure", "code": "internal_error"}'
+    )
+    response.headers["Content-Type"] = "application/json"
+    return response
+
+
+def test_segment_custom_on_error_handler_invocation():
+    with patch(
+        "segment.analytics.request._session.post",
+        side_effect=mock_post_failure,
+    ):
+        analytics.track("test_user_id", "Test Event", {"property": "value"})
+        analytics.flush()
+
+    analytics.on_error.assert_called()


### PR DESCRIPTION
## Describe changes

I implemented a workaround that disables retries for sending analytics data, in response to issue [#130](https://github.com/zenml-io/mlstacks/issues/130). This ensures the CLI remains responsive even when the Segment analytics API is unreachable, due to network failures or blocking mechanisms like PiHole. 

- Updated `src/mlstacks/analytics/client.py` to set `max_retries` to `0`, which can be adjusted as needed.
- Wrapped the `analytics_context.track` call in a `try/except` block within the `track_event` function. This ensures the `return False` statement is reachable for error handling and logging exceptions.

### Reference to Documentation

The Segment Python library documentation did not explicitly mention configurable options for `max_retries`, but the source code revealed a `max_retries` property in `segment/analytics/client.py`.

### Testing 

To simulate an unreachable analytics API domain at api.segment.io, I redirected all requests to this domain to 127.0.0.1 by adding the following entry in the /etc/hosts file on my Mac: 
   
```
127.0.0.1 api.segment.io
```    

Following this setup, I tested the `deploy`, `breakdown`, `output`, and `destroy` CLI commands, and confirmed it exits immediately, without hanging, after attempting to reach the analytics API domain once.


## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation
      accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting
      `develop`. If your branch wasn't based on develop read
      [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/mlstacks/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [ ] Other (add details above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option `max_retries` for enhanced control over analytics tracking.
- **Refactor**
	- Improved the reliability of event tracking in the analytics module with better error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->