### PR TITLE
Remove dashboard from release workflow

### DIFF
--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -28,8 +28,6 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
-      - name: Include latest dashboard
-        run: bash scripts/install-dashboard.sh
       - name: Build package
         run: poetry build
       - name: Mint token


### PR DESCRIPTION
Copy-paste error meant that mlstacks release process was trying to install zenml dashboard (and thus failing). this fixes that.